### PR TITLE
Updated to 'enableLargerThanScreen

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function electronImageResize(params) {
       height: opts.height,
       show: false,
       frame: false,
-      'enable-larger-than-screen': true,
+      'enableLargerThanScreen': true,
       'node-integration': false
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-image-resize",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Resize images using Electron. Supports all image types that Chromium/Electron supports, outputs to png, jpeg, dataUrl or NativeImage.",
   "license": "MIT",
   "repository": "davej/electron-image-resize",
@@ -30,7 +30,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "electron-prebuilt": "^0.36.10",
+    "electron-prebuilt": "^0.37.5",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.1.0"
   }


### PR DESCRIPTION
This updates a deprecated term:

'enable-larger-than-screen' becomes enableLargerThanScreen.
