### PR TITLE
Single dimension input

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var electron = require('electron');
 var BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
+var nativeImage = electron.nativeImage;
 
 module.exports = function electronImageResize(params) {
   var opts = params || {};
@@ -10,12 +11,18 @@ module.exports = function electronImageResize(params) {
       reject(new TypeError('Expected option: `url` of type string'));
     }
 
+    var originalSize = nativeImage.createFromPath(opts.url).getSize();
+
+    if (typeof opts.height !== 'number' && typeof opts.width !== 'number') {
+      reject(new TypeError('Expected option: `height` or `width` of type number'));
+    }
+
     if (typeof opts.height !== 'number') {
-      reject(new TypeError('Expected option: `height` of type number'));
+      opts.height = parseInt(originalSize.height * opts.width / originalSize.width);
     }
 
     if (typeof opts.width !== 'number') {
-      reject(new TypeError('Expected option: `width` of type number'));
+      opts.width = parseInt(originalSize.width * opts.height / originalSize.height);
     }
 
     if (typeof opts.delay !== 'number') {

--- a/index.js
+++ b/index.js
@@ -16,15 +16,17 @@ module.exports = function electronImageResize(params) {
       reject(new TypeError('Expected option: `height` or `width` of type number'));
     }
 
-    var imageLocation = opts.url.replace('file://', '');
-    var originalSize = nativeImage.createFromPath(imageLocation).getSize();
+    if (!(typeof opts.height === 'number' && typeof opts.width === 'number')) {
+      var imageLocation = opts.url.replace('file://', '');
+      var originalSize = nativeImage.createFromPath(imageLocation).getSize();
 
-    if (typeof opts.height !== 'number') {
-      opts.height = parseInt(originalSize.height * opts.width / originalSize.width);
-    }
+      if (typeof opts.height !== 'number') {
+        opts.height = parseInt(originalSize.height * opts.width / originalSize.width);
+      }
 
-    if (typeof opts.width !== 'number') {
-      opts.width = parseInt(originalSize.width * opts.height / originalSize.height);
+      if (typeof opts.width !== 'number') {
+        opts.width = parseInt(originalSize.width * opts.height / originalSize.height);
+      }
     }
 
     if (typeof opts.delay !== 'number') {

--- a/index.js
+++ b/index.js
@@ -22,9 +22,7 @@ module.exports = function electronImageResize(params) {
 
       if (typeof opts.height !== 'number') {
         opts.height = parseInt(originalSize.height * opts.width / originalSize.width);
-      }
-
-      if (typeof opts.width !== 'number') {
+      } else {
         opts.width = parseInt(originalSize.width * opts.height / originalSize.height);
       }
     }

--- a/index.js
+++ b/index.js
@@ -7,15 +7,17 @@ var nativeImage = electron.nativeImage;
 module.exports = function electronImageResize(params) {
   var opts = params || {};
   return new Promise((resolve, reject) => {
+
     if (typeof opts.url !== 'string') {
       reject(new TypeError('Expected option: `url` of type string'));
     }
 
-    var originalSize = nativeImage.createFromPath(opts.url).getSize();
-
     if (typeof opts.height !== 'number' && typeof opts.width !== 'number') {
       reject(new TypeError('Expected option: `height` or `width` of type number'));
     }
+
+    var imageLocation = opts.url.replace('file://', '');
+    var originalSize = nativeImage.createFromPath(imageLocation).getSize();
 
     if (typeof opts.height !== 'number') {
       opts.height = parseInt(originalSize.height * opts.width / originalSize.width);

--- a/readme.md
+++ b/readme.md
@@ -41,19 +41,14 @@ Type: `string`
 
 URL of image to resize. For local paths prefix the path with '`file://`'.
 
-##### width
+##### width and height
 
 Type: `number`  
-*Required*
+*At Least One Is Required*
 
 The width in pixels to resize the image to.
-
-##### height
-
-Type: `number`  
-*Required*
-
 The height in pixels to resize the image to.
+If only one dimension is provided, the image will be re-sized so that the original height/width ratio is maintained.
 
 ##### delay
 


### PR DESCRIPTION
This PR eliminates the need for the user to pass in both the height and width and makes it so only one is required. If a user passes in only a height, for example, the function will calculate the corresponding width that maintains the original image's height/width proportions. If a user passes in both a height and width, it will use the user-provided values.

It calculates the proportional dimension by creating an instance of nativeImage and calling getSize(). Using the original dimension proportions and the user-provided input, it can calculate the missing dimension.

Also updated the Readme to reflect the new requirements.
